### PR TITLE
Implement role-based dashboard and admin features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 1. Docker と Docker Compose をインストールします。
 2. 初回起動時にマイグレーションを手動で実行します。
    ```bash
-   docker compose up db -d
-   # Linux/Mac の場合
-   docker compose exec -T db psql -U postgres -d attendance < backend/migrations/001_create_tables.sql
+ docker compose up db -d
+  # Linux/Mac の場合
+ docker compose exec -T db psql -U postgres -d attendance < backend/migrations/001_create_tables.sql
+  docker compose exec -T db psql -U postgres -d attendance < backend/migrations/002_seed_admin.sql
    ```
    PowerShell では `<` リダイレクトが使用できないため、次のようにファイル内容をパイプで渡してください。
    ```powershell
@@ -18,9 +19,12 @@
    ```
 3. サービスを起動します。
    ```bash
-   docker compose up
-   ```
+ docker compose up
+  ```
 4. フロントエンドは <http://localhost:8080>、API は <http://localhost:3000> にアクセスします。
+5. `ADMIN_EMAILS` 環境変数で管理者アカウントのメールアドレスをカンマ区切りで指定できます。デフォルトでは `admin@example.com` が含まれています。
+
+フロントエンドは静的 HTML で構成されているためビルド工程はありません。そのまま nginx コンテナから配信されます。
 
 テスト実行方法:
 ```bash
@@ -75,3 +79,7 @@ ER 図やシーケンス図は `docs/` フォルダーに配置しています�
 ## CI/CD（任意）
 
 CI/CD を試したい方向けに、GitHub Actions のワークフロー (`.github/workflows/nodejs.yml`) を用意しています。
+
+## UI スクリーンショット
+
+ダッシュボード、日報入力画面、管理者ダッシュボードの例をここに掲載する予定です。(画像ファイルはリポジトリには含めていません)

--- a/backend/migrations/002_seed_admin.sql
+++ b/backend/migrations/002_seed_admin.sql
@@ -1,0 +1,3 @@
+INSERT INTO users(email, role)
+VALUES ('admin@example.com', 'admin')
+ON CONFLICT (email) DO UPDATE SET role='admin';

--- a/backend/src/middleware.js
+++ b/backend/src/middleware.js
@@ -1,0 +1,14 @@
+// Common authentication helpers
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated && req.isAuthenticated()) return next();
+  res.status(401).json({ error: 'unauthenticated' });
+}
+
+function ensureAdmin(req, res, next) {
+  if (req.isAuthenticated && req.isAuthenticated() && req.user.role === 'admin') {
+    return next();
+  }
+  res.status(403).json({ error: 'forbidden' });
+}
+
+module.exports = { ensureAuthenticated, ensureAdmin };

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const router = express.Router();
+const { ensureAuthenticated, ensureAdmin } = require('../middleware');
+
+// Get monthly hours for all users
+router.get('/hours', ensureAuthenticated, ensureAdmin, async (req, res) => {
+  const db = req.app.get('db');
+  const start = new Date();
+  start.setDate(1);
+  start.setHours(0,0,0,0);
+  const result = await db.query(
+    `SELECT u.id, u.email,
+            COALESCE(SUM(EXTRACT(EPOCH FROM (a.clock_out - a.clock_in))/3600),0) AS hours
+       FROM users u
+       LEFT JOIN attendance a ON a.user_id = u.id AND a.clock_in >= $1 AND a.clock_out IS NOT NULL
+      GROUP BY u.id, u.email
+      ORDER BY u.email`,
+    [start]
+  );
+  res.json(result.rows);
+});
+
+// Export monthly hours as CSV
+router.get('/export-hours', ensureAuthenticated, ensureAdmin, async (req, res) => {
+  const db = req.app.get('db');
+  const start = new Date();
+  start.setDate(1);
+  start.setHours(0,0,0,0);
+  const result = await db.query(
+    `SELECT u.email,
+            COALESCE(SUM(EXTRACT(EPOCH FROM (a.clock_out - a.clock_in))/3600),0) AS hours
+       FROM users u
+       LEFT JOIN attendance a ON a.user_id = u.id AND a.clock_in >= $1 AND a.clock_out IS NOT NULL
+      GROUP BY u.email
+      ORDER BY u.email`,
+    [start]
+  );
+  const lines = ['email,hours'];
+  result.rows.forEach(r => {
+    lines.push(`${r.email},${r.hours}`);
+  });
+  res.header('Content-Type', 'text/csv');
+  res.send(lines.join('\n'));
+});
+
+module.exports = router;

--- a/backend/src/routes/attendance.js
+++ b/backend/src/routes/attendance.js
@@ -1,10 +1,6 @@
 const express = require('express');
 const router = express.Router();
-
-function ensureAuthenticated(req, res, next) {
-  if (req.isAuthenticated()) { return next(); }
-  res.status(401).json({ error: 'unauthenticated' });
-}
+const { ensureAuthenticated } = require('../middleware');
 
 router.post('/clock-in', ensureAuthenticated, async (req, res) => {
   const db = req.app.get('db');
@@ -20,6 +16,24 @@ router.post('/clock-out', ensureAuthenticated, async (req, res) => {
   const now = new Date();
   await db.query('UPDATE attendance SET clock_out=$1 WHERE user_id=$2 AND clock_out IS NULL ORDER BY clock_in DESC LIMIT 1', [now, userId]);
   res.json({ status: 'clocked out', at: now });
+});
+
+// Summary of current month hours and utilization
+router.get('/summary', ensureAuthenticated, async (req, res) => {
+  const db = req.app.get('db');
+  const userId = req.user.id;
+  const start = new Date();
+  start.setDate(1);
+  start.setHours(0,0,0,0);
+  const result = await db.query(
+    `SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (clock_out - clock_in))/3600),0) AS hours
+     FROM attendance WHERE user_id=$1 AND clock_in >= $2 AND clock_out IS NOT NULL`,
+    [userId, start]
+  );
+  const totalHours = parseFloat(result.rows[0].hours);
+  const today = new Date();
+  const utilization = (totalHours / (today.getDate() * 8)) * 100;
+  res.json({ totalHours, utilization: Number(utilization.toFixed(2)) });
 });
 
 module.exports = router;

--- a/backend/src/userService.js
+++ b/backend/src/userService.js
@@ -1,0 +1,13 @@
+// Finds existing user by email or creates a new one with role based on admin email list
+async function getOrCreateUser(email, db) {
+  const adminEmails = process.env.ADMIN_EMAILS ? process.env.ADMIN_EMAILS.split(',') : [];
+  const result = await db.query('SELECT * FROM users WHERE email=$1', [email]);
+  if (result.rows.length === 0) {
+    const role = adminEmails.includes(email) ? 'admin' : 'user';
+    const insert = await db.query('INSERT INTO users(email, role) VALUES($1, $2) RETURNING *', [email, role]);
+    return insert.rows[0];
+  }
+  return result.rows[0];
+}
+
+module.exports = { getOrCreateUser };

--- a/backend/test/integration/admin.test.js
+++ b/backend/test/integration/admin.test.js
@@ -1,0 +1,20 @@
+const request = require('supertest');
+const express = require('express');
+const adminRouter = require('../../src/routes/admin');
+
+function setup(db) {
+  const app = express();
+  app.use(express.json());
+  app.set('db', db);
+  app.use((req,res,next)=>{req.isAuthenticated=()=>true; req.user={id:1,role:'admin'}; next();});
+  app.use('/admin', adminRouter);
+  return app;
+}
+
+test('export-hours returns csv', async () => {
+  const db={query: jest.fn().mockResolvedValue({rows:[{email:'a@test',hours:1}]})};
+  const app = setup(db);
+  const res = await request(app).get('/admin/export-hours');
+  expect(res.header['content-type']).toMatch(/text\/csv/);
+  expect(res.text).toContain('a@test');
+});

--- a/backend/test/integration/attendance.test.js
+++ b/backend/test/integration/attendance.test.js
@@ -1,0 +1,28 @@
+const request = require('supertest');
+const express = require('express');
+const attendanceRouter = require('../../src/routes/attendance');
+
+function setup(db) {
+  const app = express();
+  app.use(express.json());
+  app.set('db', db);
+  // mock auth
+  app.use((req,res,next)=>{req.isAuthenticated=()=>true; req.user={id:1,role:'user'}; next();});
+  app.use('/attendance', attendanceRouter);
+  return app;
+}
+
+test('clock-in inserts attendance record', async () => {
+  const queries=[];
+  const db={query: jest.fn().mockResolvedValue({rows:[]})};
+  const app = setup(db);
+  await request(app).post('/attendance/clock-in');
+  expect(db.query).toHaveBeenCalled();
+});
+
+test('clock-out updates attendance record', async () => {
+  const db={query: jest.fn().mockResolvedValue({rows:[]})};
+  const app = setup(db);
+  await request(app).post('/attendance/clock-out');
+  expect(db.query).toHaveBeenCalled();
+});

--- a/backend/test/integration/report.test.js
+++ b/backend/test/integration/report.test.js
@@ -1,0 +1,19 @@
+const request = require('supertest');
+const express = require('express');
+const reportRouter = require('../../src/routes/report');
+
+function setup(db) {
+  const app = express();
+  app.use(express.json());
+  app.set('db', db);
+  app.use((req,res,next)=>{req.isAuthenticated=()=>true; req.user={id:1,role:'user'}; next();});
+  app.use('/report', reportRouter);
+  return app;
+}
+
+test('rejects report submission without clock-in', async () => {
+  const db={query: jest.fn().mockResolvedValue({rows:[]})};
+  const app = setup(db);
+  const res = await request(app).post('/report/').send({markdown:'test'});
+  expect(res.status).toBe(400);
+});

--- a/backend/test/unit/userService.test.js
+++ b/backend/test/unit/userService.test.js
@@ -1,0 +1,29 @@
+const { getOrCreateUser } = require('../../src/userService');
+
+// Mock DB client with query function
+function mockDb(returnRows = []) {
+  return {
+    queries: [],
+    async query(sql, params) {
+      this.queries.push({ sql, params });
+      if (/INSERT/.test(sql)) {
+        return { rows: [{ id: 1, email: params[0], role: params[1] }] };
+      }
+      return { rows: returnRows };
+    }
+  };
+}
+
+test('assigns admin role when email is in ADMIN_EMAILS', async () => {
+  process.env.ADMIN_EMAILS = 'admin@example.com';
+  const db = mockDb([]); // user does not exist
+  const user = await getOrCreateUser('admin@example.com', db);
+  expect(user.role).toBe('admin');
+});
+
+test('keeps existing user role if found', async () => {
+  process.env.ADMIN_EMAILS = 'admin@example.com';
+  const db = mockDb([{ id:2, email:'user@example.com', role:'user' }]);
+  const user = await getOrCreateUser('user@example.com', db);
+  expect(user.role).toBe('user');
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
     ports:
-      - '5432:5432'
+      - '127.0.0.1:5432:5432'
 
   api:
     build: ./backend
@@ -20,6 +20,7 @@ services:
       AZURE_CLIENT_ID: change_me
       AZURE_CLIENT_SECRET: change_me
       AZURE_TENANT_ID: change_me
+      ADMIN_EMAILS: admin@example.com
     depends_on:
       - db
     volumes:

--- a/frontend/public/admin_dashboard.html
+++ b/frontend/public/admin_dashboard.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Admin Dashboard</title>
+</head>
+<body>
+  <h1>Admin Dashboard</h1>
+  <table id="table" border="1"></table>
+  <button id="csv">Download CSV</button>
+  <script>
+  async function load(){
+    const res = await fetch('/admin/hours');
+    if(res.ok){
+      const data = await res.json();
+      const rows = data.map(u => `<tr><td>${u.email}</td><td>${u.hours}</td></tr>`).join('');
+      document.getElementById('table').innerHTML = '<tr><th>Email</th><th>Hours</th></tr>' + rows;
+    }
+  }
+  document.getElementById('csv').onclick = () => { window.location='/admin/export-hours'; };
+  load();
+  </script>
+</body>
+</html>

--- a/frontend/public/dashboard.html
+++ b/frontend/public/dashboard.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
+  <style>
+    #preview { border: 1px solid #ccc; padding: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Dashboard</h1>
+  <button id="clockIn">Clock In</button>
+  <button id="clockOut">Clock Out</button>
+  <div id="result"></div>
+  <div id="summary"></div>
+  <p>
+    <a href="/reports/new">New Report</a> |
+    <a href="/reports">My Reports</a> |
+    <a href="/admin/dashboard" id="adminLink" style="display:none;">Admin Dashboard</a>
+  </p>
+<script>
+async function refreshSummary() {
+  const res = await fetch('/attendance/summary');
+  if(res.ok){
+    const data = await res.json();
+    document.getElementById('summary').textContent = `This month: ${data.totalHours.toFixed(2)}h (utilization ${data.utilization}%)`;
+  }
+}
+
+document.getElementById('clockIn').onclick = async () => {
+  const res = await fetch('/attendance/clock-in', {method:'POST'});
+  document.getElementById('result').textContent = res.ok ? 'Clocked in' : 'Error';
+  refreshSummary();
+};
+
+document.getElementById('clockOut').onclick = async () => {
+  const res = await fetch('/attendance/clock-out', {method:'POST'});
+  document.getElementById('result').textContent = res.ok ? 'Clocked out' : 'Error';
+  refreshSummary();
+};
+
+async function init(){
+  const me = await fetch('/me');
+  if(me.ok){
+    const user = await me.json();
+    if(user.role === 'admin') document.getElementById('adminLink').style.display='inline';
+  }
+  refreshSummary();
+}
+init();
+</script>
+</body>
+</html>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,6 +7,7 @@
 <body>
   <h1>Attendance Management</h1>
   <a href="/auth/login">Sign In with Microsoft</a>
+  <p><a href="/dashboard">Go to Dashboard</a></p>
   <div id="app"></div>
 </body>
 </html>

--- a/frontend/public/reports.html
+++ b/frontend/public/reports.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Reports</title>
+</head>
+<body>
+  <h1>My Reports</h1>
+  <div id="list"></div>
+  <script>
+  async function load(){
+    const res = await fetch('/report/');
+    if(res.ok){
+      const list = await res.json();
+      document.getElementById('list').innerHTML = list.map(r => `<h3>${r.date}</h3>`+r.html).join('');
+    }
+  }
+  load();
+  </script>
+</body>
+</html>

--- a/frontend/public/reports_new.html
+++ b/frontend/public/reports_new.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>New Report</title>
+  <script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
+</head>
+<body>
+  <h1>Submit Report</h1>
+  <textarea id="markdown" rows="10" cols="60"></textarea>
+  <div id="preview"></div>
+  <div id="error" style="color:red;"></div>
+  <button id="submit">Submit</button>
+  <script>
+  const md = window.markdownit();
+  const ta = document.getElementById('markdown');
+  ta.addEventListener('input', () => {
+    document.getElementById('preview').innerHTML = md.render(ta.value);
+  });
+
+  document.getElementById('submit').onclick = async () => {
+    const res = await fetch('/report/', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({markdown: ta.value})});
+    if(res.ok){
+      location.href = '/reports';
+    }else{
+      const data = await res.json();
+      document.getElementById('error').textContent = data.error || 'error';
+    }
+  };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- assign role during login via `getOrCreateUser`
- expose `/me`, `/attendance/summary`, admin routes and middleware
- provide admin CSV export endpoint and monthly hours
- add frontend pages for dashboard and admin functions
- seed default admin and lock db port to localhost
- add Jest tests for new features
- document setup, seeding, frontend usage and screenshots

## Testing
- `npm test -- -i --silent`


------
https://chatgpt.com/codex/tasks/task_e_6857eca38280832497c1e1702acf8729