### PR TITLE
Add local login option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
    ```
 4. フロントエンドは <http://localhost:8080>、API は <http://localhost:3000> にアクセスします。
 5. `ADMIN_EMAILS` 環境変数で管理者アカウントのメールアドレスをカンマ区切りで指定できます。デフォルトでは `admin@example.com` が含まれています。
+6. Microsoft Entra ID を利用せずにテストする場合は、環境変数 `USE_LOCAL_LOGIN=true` を設定すると `/api/auth/login` でシンプルなメールアドレス入力フォームが表示されます。
 
 フロントエンドは静的 HTML で構成されているためビルド工程はありません。そのまま nginx コンテナから配信されます。
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,14 +1,44 @@
 const express = require('express');
 const passport = require('passport');
+const { getOrCreateUser } = require('../userService');
 const router = express.Router();
 
-router.get('/login', passport.authenticate('azuread-openidconnect'));
+const useLocal = process.env.USE_LOCAL_LOGIN === 'true';
 
-router.post('/openid/return', passport.authenticate('azuread-openidconnect', {
-  failureRedirect: '/login'
-}), (req, res) => {
-  res.redirect('/');
-});
+if (useLocal) {
+  router.get('/login', (req, res) => {
+    res.send(
+      `<form method="post" action="/auth/login">` +
+      `<input type="email" name="email" required />` +
+      `<button type="submit">Login</button>` +
+      `</form>`
+    );
+  });
+
+  router.post('/login', async (req, res, next) => {
+    try {
+      const email = req.body.email;
+      if (!email) return res.status(400).send('email required');
+      const user = await getOrCreateUser(email, req.app.get('db'));
+      req.login(user, (err) => {
+        if (err) return next(err);
+        res.redirect('/');
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+} else {
+  router.get('/login', passport.authenticate('azuread-openidconnect'));
+
+  router.post(
+    '/openid/return',
+    passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
+    (req, res) => {
+      res.redirect('/');
+    }
+  );
+}
 
 router.get('/logout', (req, res) => {
   req.logout(() => {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,6 +12,7 @@ const { getOrCreateUser } = require('./userService');
 
 const app = express();
 app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
 
 // Database connection
 const pool = new Pool({


### PR DESCRIPTION
## Summary
- add URL encoded body parser for form submissions
- allow simple local login when USE_LOCAL_LOGIN=true
- document the new option in README

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_685809ec46b483249c8dbe3d305c0ab5