### PR TITLE
Add local login option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# node_modules
-# backend/node_modules
-# .env
-# .DS_Store
+node_modules/
+backend/node_modules/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
    ```
 4. フロントエンドは <http://localhost:8080>、API は <http://localhost:3000> にアクセスします。
 5. `ADMIN_EMAILS` 環境変数で管理者アカウントのメールアドレスをカンマ区切りで指定できます。デフォルトでは `admin@example.com` が含まれています。
-6. Microsoft Entra ID を利用せずにテストする場合は、環境変数 `USE_LOCAL_LOGIN=true` を設定すると `/api/auth/login` でシンプルなメールアドレス入力フォームが表示されます。
+6. Microsoft Entra ID を利用せずにテストする場合は、環境変数 `USE_LOCAL_LOGIN=true` を設定すると `/api/auth/login` でシンプルなメールアドレス入力フォームが表示されます。Docker Compose を使用せずバックエンドを直接起動する場合は `http://localhost:3000/auth/login` を開いてください。
 
 フロントエンドは静的 HTML で構成されているためビルド工程はありません。そのまま nginx コンテナから配信されます。
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
    ```
 4. フロントエンドは <http://localhost:8080>、API は <http://localhost:3000> にアクセスします。
 5. `ADMIN_EMAILS` 環境変数で管理者アカウントのメールアドレスをカンマ区切りで指定できます。デフォルトでは `admin@example.com` が含まれています。
+6. Microsoft Entra ID を利用せずにテストする場合は、環境変数 `USE_LOCAL_LOGIN=true` を設定すると `/api/auth/login` でシンプルなメールアドレス入力フォームが表示されます。
 
 フロントエンドは静的 HTML で構成されているためビルド工程はありません。そのまま nginx コンテナから配信されます。
 
@@ -59,6 +60,7 @@ Windows 環境でアプリを動作確認する場合は、PowerShell で以下�
    ```
 4. すべてのコンテナを起動します。
    ```powershell
+   $env:USE_LOCAL_LOGIN="true"   # ローカルログインを使う場合
    docker compose up
    ```
    フロントエンドは <http://localhost:8080/> 、API のヘルスチェックは <http://localhost:3000/health> で確認できます。

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,14 +1,44 @@
 const express = require('express');
 const passport = require('passport');
+const { getOrCreateUser } = require('../userService');
 const router = express.Router();
 
-router.get('/login', passport.authenticate('azuread-openidconnect'));
+const useLocal = process.env.USE_LOCAL_LOGIN === 'true';
 
-router.post('/openid/return', passport.authenticate('azuread-openidconnect', {
-  failureRedirect: '/login'
-}), (req, res) => {
-  res.redirect('/');
-});
+if (useLocal) {
+  router.get('/login', (req, res) => {
+    res.send(
+      `<form method="post" action="/api/auth/login">` +
+      `<input type="email" name="email" required />` +
+      `<button type="submit">Login</button>` +
+      `</form>`
+    );
+  });
+
+  router.post('/login', async (req, res, next) => {
+    try {
+      const email = req.body.email;
+      if (!email) return res.status(400).send('email required');
+      const user = await getOrCreateUser(email, req.app.get('db'));
+      req.login(user, (err) => {
+        if (err) return next(err);
+        res.redirect('/');
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+} else {
+  router.get('/login', passport.authenticate('azuread-openidconnect'));
+
+  router.post(
+    '/openid/return',
+    passport.authenticate('azuread-openidconnect', { failureRedirect: '/login' }),
+    (req, res) => {
+      res.redirect('/');
+    }
+  );
+}
 
 router.get('/logout', (req, res) => {
   req.logout(() => {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -10,8 +10,11 @@ const reportRoutes = require('./routes/report');
 const adminRoutes = require('./routes/admin');
 const { getOrCreateUser } = require('./userService');
 
+const useLocal = process.env.USE_LOCAL_LOGIN === 'true';
+
 const app = express();
 app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
 
 // Database connection
 const pool = new Pool({
@@ -20,31 +23,32 @@ const pool = new Pool({
 
 app.set('db', pool);
 
-// Passport setup for Microsoft Entra ID (Azure AD)
-const oidcConfig = {
-  identityMetadata: `https://login.microsoftonline.com/${process.env.AZURE_TENANT_ID}/v2.0/.well-known/openid-configuration`,
-  clientID: process.env.AZURE_CLIENT_ID,
-  responseType: 'code',
-  responseMode: 'query',
-  redirectUrl: process.env.AZURE_REDIRECT_URL || 'http://localhost:3000/auth/openid/return',
-  allowHttpForRedirectUrl: true,
-  clientSecret: process.env.AZURE_CLIENT_SECRET,
-  validateIssuer: false,
-  passReqToCallback: false,
-  scope: ['profile', 'email']
-};
+if (!useLocal) {
+  // Passport setup for Microsoft Entra ID (Azure AD)
+  const oidcConfig = {
+    identityMetadata: `https://login.microsoftonline.com/${process.env.AZURE_TENANT_ID}/v2.0/.well-known/openid-configuration`,
+    clientID: process.env.AZURE_CLIENT_ID,
+    responseType: 'code',
+    responseMode: 'query',
+    redirectUrl: process.env.AZURE_REDIRECT_URL || 'http://localhost:3000/auth/openid/return',
+    allowHttpForRedirectUrl: true,
+    clientSecret: process.env.AZURE_CLIENT_SECRET,
+    validateIssuer: false,
+    passReqToCallback: false,
+    scope: ['profile', 'email']
+  };
 
-passport.use(new OIDCStrategy(oidcConfig, async (iss, sub, profile, accessToken, refreshToken, done) => {
-  try {
-    const email = profile._json.preferred_username;
-    const db = pool;
-    // Determine role and create the user if necessary
-    const user = await getOrCreateUser(email, db);
-    return done(null, user);
-  } catch (err) {
-    return done(err);
-  }
-}));
+  passport.use(new OIDCStrategy(oidcConfig, async (iss, sub, profile, accessToken, refreshToken, done) => {
+    try {
+      const email = profile._json.preferred_username;
+      const db = pool;
+      const user = await getOrCreateUser(email, db);
+      return done(null, user);
+    } catch (err) {
+      return done(err);
+    }
+  }));
+}
 
 passport.serializeUser((user, done) => {
   done(null, user.id);


### PR DESCRIPTION
## Summary
- add URL encoded body parser for form submissions
- allow simple local login when USE_LOCAL_LOGIN=true
- document the new option in README

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_685809ec46b483249c8dbe3d305c0ab5