### PR TITLE
Fix login with missing Azure AD config

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -10,7 +10,15 @@ const reportRoutes = require('./routes/report');
 const adminRoutes = require('./routes/admin');
 const { getOrCreateUser } = require('./userService');
 
-const useLocal = process.env.USE_LOCAL_LOGIN === 'true';
+// Switch to local login when USE_LOCAL_LOGIN=true or when Azure AD
+// credentials are not properly configured. This allows easier local testing
+// without Microsoft Entra ID.
+const azureConfigured =
+  process.env.AZURE_CLIENT_ID &&
+  process.env.AZURE_CLIENT_SECRET &&
+  process.env.AZURE_TENANT_ID &&
+  process.env.AZURE_CLIENT_ID !== 'change_me';
+const useLocal = process.env.USE_LOCAL_LOGIN === 'true' || !azureConfigured;
 
 const app = express();
 app.use(bodyParser.json());


### PR DESCRIPTION
## Summary
- avoid failing Azure AD login when placeholder values are used
- fallback to local login automatically when Azure env vars are missing

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6858a1264fd083249338294c7a91faa4