### PR TITLE
Fix local login detection for auth route

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -3,7 +3,13 @@ const passport = require('passport');
 const { getOrCreateUser } = require('../userService');
 const router = express.Router();
 
-const useLocal = process.env.USE_LOCAL_LOGIN === 'true';
+// Determine whether to use local login based on the same logic as server.js.
+const azureConfigured =
+  process.env.AZURE_CLIENT_ID &&
+  process.env.AZURE_CLIENT_SECRET &&
+  process.env.AZURE_TENANT_ID &&
+  process.env.AZURE_CLIENT_ID !== 'change_me';
+const useLocal = process.env.USE_LOCAL_LOGIN === 'true' || !azureConfigured;
 
 if (useLocal) {
   router.get('/login', (req, res) => {


### PR DESCRIPTION
## Summary
- ensure auth route falls back to local login when Azure settings are missing

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6858a60ec4288324b5e15aa95864b918